### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, except: [:index, :show]  # ログインしていることを確認
+  before_action :contributor_confirmation, only: [:edit, :update] # 現在のユーザーとアイテム投稿者が一致していることを確認
+
   def index
     @items = Item.includes(:user).order(created_at: :desc) # 新着順にソート
   end
@@ -22,14 +24,24 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def update
+    @item = Item.find(params[:id]) # 編集したいレコードを取得
+    if @item.update(item_params)# 取得したレコードをupdateメソッドで更新
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
-    # @item.destroy
-    # redirect_to root_path
+    # @item = Item.find(params[:id]) 
+    # if @item.destroy
+    #   redirect_to root_path
+    # else
+    #   redirect_to root_path
   end
 
   private
@@ -46,5 +58,10 @@ class ItemsController < ApplicationController
       :image,
       :price
     ).merge(user_id: current_user.id)
+  end
+
+  def contributor_confirmation
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user == @item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]  # ログインしていることを確認
   before_action :contributor_confirmation, only: [:edit, :update] # 現在のユーザーとアイテム投稿者が一致していることを確認
 
@@ -20,15 +21,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id]) # 編集したいレコードを取得
+    #@item = Item.find(params[:id]) # 編集したいレコードを取得
     if @item.update(item_params)# 取得したレコードをupdateメソッドで更新
       redirect_to item_path(@item)
     else
@@ -37,7 +36,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    # @item = Item.find(params[:id]) 
     # if @item.destroy
     #   redirect_to root_path
     # else
@@ -60,8 +58,11 @@ class ItemsController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 
-  def contributor_confirmation
+  def set_item
     @item = Item.find(params[:id])
+   end
+
+  def contributor_confirmation
     redirect_to root_path unless current_user == @item.user
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,12 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with model: @item,data: { turbo: false }, local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -23,7 +20,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +30,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :title_description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +49,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipp_fee_id, ShippFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipp_date_id, ShippDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -94,29 +91,29 @@ app/assets/stylesheets/items/new.css %>
         <span>販売価格<br>(¥300〜9,999,999)</span>
         <a class="question" href="#">?</a>
       </div>
-      <div>
-        <div class="price-content">
+    <div>
+       <div class="price-content">
           <div class="price-text">
-            <span>価格</span>
-            <span class="indispensable">必須</span>
+             <span>価格</span>
+             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+       </div>
+       <div class="price-content">
           <span>販売手数料 (10%)</span>
           <span>
             <span id='add-tax-price'></span>円
           </span>
-        </div>
-        <div class="price-content">
+       </div>
+       <div class="price-content">
           <span>販売利益</span>
           <span>
-            <span id='profit'></span>円
+          <span id='profit'></span>円
           </span>
         </div>
-      </div>
     </div>
+  </div>
     <%# /販売価格 %>
 
     <%# 注意書き %>
@@ -141,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -138,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
     <%# ログイン中の出品者で、未購入品の場合 %>
     <% if user_signed_in? %>
       <% if current_user == @item.user%>
-        <%= link_to '商品の編集', "#", class: 'item-red-btn' %>
+        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: 'item-red-btn' %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", class:'item-destroy' %>
       <% else %>


### PR DESCRIPTION
# What
商品情報編集機能の作成

# Wht
商品情報編集機能の実装のため

・ログイン状態の出品者は、商品情報編集ページに遷移できる
　https://gyazo.com/473e31eaa042a7bd34fd07c0061f3440
 ・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる
 　https://gyazo.com/b35c71ab6e8897372c82f1b31a8b31ea
 ・入力に問題がある状態で「変更する」が押された場合、情報は保存されず、編集ページに戻りエラー表示される
　https://gyazo.com/4e42a4a797a81d989355e6866fa49365
 ・何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
　https://gyazo.com/9aac353a264bb0a63104d3500fd75890
 ・ログイン状態で自身が出品していない商品の編集ページにURLから直接アクセスするとトップページに遷移
    https://gyazo.com/6a4c3762c64b6cea13ef78b9c6fcd7e5
 ・ログアウト状態で商品の編集ページにURLから直接アクセスするとログインページに遷移
 　https://gyazo.com/80576fd0a0f802d336cc5ab2389d9ed6
 ・商品名の情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される
 　https://gyazo.com/aee8b8a391d844e78bdebc8266860037